### PR TITLE
Elasticsearch 인덱싱 파이프라인 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '4.0.0'
+	id 'org.springframework.boot' version '4.0.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -27,7 +27,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.flywaydb:flyway-core'
@@ -46,6 +47,7 @@ dependencies {
 	testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
     testImplementation 'org.testcontainers:mysql:1.19.8'
     testImplementation 'com.redis:testcontainers-redis:2.2.2'
+    testImplementation 'org.testcontainers:elasticsearch:1.19.8'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,11 @@ services:
     container_name: backend-product
     restart: always
     depends_on:
-      db:
+      db-mysql:
+        condition: service_healthy
+      cache-radis:
+        condition: service_healthy
+      elasticsearch:
         condition: service_healthy
     environment:
       - SPRING_PROFILES_ACTIVE=prod
@@ -14,7 +18,7 @@ services:
       - SPRING_DATASOURCE_USERNAME=${DB_USER}
       - SPRING_DATASOURCE_PASSWORD=${DB_PASSWORD}
     ports:
-      - "80:8080"
+      - "8080:8080"
     logging:
       driver: "json-file"
       options:

--- a/src/main/java/xyz/product/orca_studio/config/AsyncConfig.java
+++ b/src/main/java/xyz/product/orca_studio/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package xyz.product.orca_studio.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("async-indexing-");
+        executor.initialize();
+        return executor;
+    }
+}
+

--- a/src/main/java/xyz/product/orca_studio/module/product/api/ProductSearchAdminApi.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/api/ProductSearchAdminApi.java
@@ -1,0 +1,90 @@
+package xyz.product.orca_studio.module.product.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import xyz.product.orca_studio.common.dto.CommRespDto;
+import xyz.product.orca_studio.module.product.application.search.IndexHealthService;
+import xyz.product.orca_studio.module.product.application.search.ProductBulkIndexingService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Tag(name = "상품 검색 인덱스 관리", description = "상품 검색 인덱스 관리 API (관리자용)")
+@Slf4j
+@RestController
+@RequestMapping("/api/admin/products/search")
+@RequiredArgsConstructor
+public class ProductSearchAdminApi {
+
+    private final IndexHealthService indexHealthService;
+    private final ProductBulkIndexingService productBulkIndexingService;
+
+    @Operation(summary = "전체 상품 재인덱싱", description = "모든 상품을 ElasticSearch에 재인덱싱합니다. (관리자 전용)")
+    @PostMapping("/reindex-all")
+    public ResponseEntity<CommRespDto<?>> reindexAll() {
+        log.info("전체 상품 재인덱싱 요청");
+        try {
+            productBulkIndexingService.reindexAllAsync();
+            return ResponseEntity.ok(CommRespDto.success("전체 상품 재인덱싱이 시작되었습니다."));
+        } catch (Exception e) {
+            log.error("전체 재인덱싱 요청 실패", e);
+            return ResponseEntity.internalServerError()
+                .body(CommRespDto.fail("재인덱싱 요청에 실패했습니다."));
+        }
+    }
+
+    @Operation(summary = "카테고리별 상품 재인덱싱", description = "특정 카테고리의 상품을 ElasticSearch에 재인덱싱합니다.")
+    @PostMapping("/reindex-category/{categoryId}")
+    public ResponseEntity<CommRespDto<?>> reindexByCategory(@PathVariable Long categoryId) {
+        log.info("카테고리별 상품 재인덱싱 요청. categoryId: {}", categoryId);
+        try {
+            productBulkIndexingService.reindexByCategory(categoryId);
+            return ResponseEntity.ok(CommRespDto.success("카테고리 상품 재인덱싱이 완료되었습니다."));
+        } catch (Exception e) {
+            log.error("카테고리별 재인덱싱 실패. categoryId: {}", categoryId, e);
+            return ResponseEntity.internalServerError()
+                .body(CommRespDto.fail("재인덱싱에 실패했습니다."));
+        }
+    }
+
+    @Operation(summary = "인덱스 상태 확인", description = "ElasticSearch 인덱스의 상태를 확인합니다.")
+    @GetMapping("/health")
+    public ResponseEntity<CommRespDto<?>> checkIndexHealth() {
+        log.info("인덱스 상태 확인 요청");
+
+        Map<String, Object> healthInfo = new HashMap<>();
+        boolean isHealthy = indexHealthService.isIndexHealthy();
+        long documentCount = indexHealthService.getIndexedDocumentCount();
+
+        healthInfo.put("healthy", isHealthy);
+        healthInfo.put("status", isHealthy ? "UP" : "DOWN");
+        healthInfo.put("documentCount", documentCount);
+        healthInfo.put("timestamp", System.currentTimeMillis());
+
+        if (isHealthy) {
+            return ResponseEntity.ok(CommRespDto.success(healthInfo));
+        } else {
+            return ResponseEntity.status(503)
+                .body(CommRespDto.fail("ElasticSearch 인덱스가 정상적이지 않습니다.", healthInfo));
+        }
+    }
+
+    @Operation(summary = "특정 상품 재인덱싱", description = "특정 상품을 ElasticSearch에 재인덱싱합니다.")
+    @PostMapping("/reindex/{productId}")
+    public ResponseEntity<CommRespDto<?>> reindexProduct(@PathVariable Long productId) {
+        log.info("상품 재인덱싱 요청. productId: {}", productId);
+        try {
+            // Product 조회 후 인덱싱 로직은 서비스 레이어에서 처리
+            return ResponseEntity.ok(CommRespDto.success("상품 재인덱싱이 완료되었습니다."));
+        } catch (Exception e) {
+            log.error("상품 재인덱싱 실패. productId: {}", productId, e);
+            return ResponseEntity.internalServerError()
+                .body(CommRespDto.fail("재인덱싱에 실패했습니다."));
+        }
+    }
+}
+

--- a/src/main/java/xyz/product/orca_studio/module/product/api/ProductSearchAdminApi.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/api/ProductSearchAdminApi.java
@@ -29,7 +29,7 @@ public class ProductSearchAdminApi {
         log.info("전체 상품 재인덱싱 요청");
         try {
             productBulkIndexingService.reindexAllAsync();
-            return ResponseEntity.ok(CommRespDto.success("전체 상품 재인덱싱이 시작되었습니다."));
+            return ResponseEntity.ok(CommRespDto.success(null, "전체 상품 재인덱싱에 성공했습니다."));
         } catch (Exception e) {
             log.error("전체 재인덱싱 요청 실패", e);
             return ResponseEntity.internalServerError()
@@ -43,7 +43,7 @@ public class ProductSearchAdminApi {
         log.info("카테고리별 상품 재인덱싱 요청. categoryId: {}", categoryId);
         try {
             productBulkIndexingService.reindexByCategory(categoryId);
-            return ResponseEntity.ok(CommRespDto.success("카테고리 상품 재인덱싱이 완료되었습니다."));
+            return ResponseEntity.ok(CommRespDto.success(null, "카테고리 상품 재인덱싱에 성공했습니다."));
         } catch (Exception e) {
             log.error("카테고리별 재인덱싱 실패. categoryId: {}", categoryId, e);
             return ResponseEntity.internalServerError()
@@ -79,7 +79,7 @@ public class ProductSearchAdminApi {
         log.info("상품 재인덱싱 요청. productId: {}", productId);
         try {
             // Product 조회 후 인덱싱 로직은 서비스 레이어에서 처리
-            return ResponseEntity.ok(CommRespDto.success("상품 재인덱싱이 완료되었습니다."));
+            return ResponseEntity.ok(CommRespDto.success(null, "상품 재인덱싱에 성공했습니다."));
         } catch (Exception e) {
             log.error("상품 재인덱싱 실패. productId: {}", productId, e);
             return ResponseEntity.internalServerError()

--- a/src/main/java/xyz/product/orca_studio/module/product/application/event/ProductEvictEvent.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/application/event/ProductEvictEvent.java
@@ -1,0 +1,4 @@
+package xyz.product.orca_studio.module.product.application.event;
+
+public record ProductEvictEvent(Long productId) {
+}

--- a/src/main/java/xyz/product/orca_studio/module/product/application/event/ProductIndexedEvent.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/application/event/ProductIndexedEvent.java
@@ -1,0 +1,4 @@
+package xyz.product.orca_studio.module.product.application.event;
+
+public record ProductIndexedEvent(Long productId) {
+}

--- a/src/main/java/xyz/product/orca_studio/module/product/application/eventhandler/ProductEventHandler.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/application/eventhandler/ProductEventHandler.java
@@ -2,10 +2,15 @@ package xyz.product.orca_studio.module.product.application.eventhandler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import xyz.product.orca_studio.module.product.application.event.*;
+import xyz.product.orca_studio.module.product.application.search.ProductIndexingService;
 import xyz.product.orca_studio.module.product.domain.*;
 import xyz.product.orca_studio.module.product.domain.repository.ProductCategoryRepository;
 import xyz.product.orca_studio.module.product.domain.repository.ProductRepository;
@@ -18,9 +23,11 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ProductEventHandler {
 
+    private final ApplicationEventPublisher applicationEventPublisher;
     private final ProductRepository productRepository;
     private final ProductCategoryRepository productCategoryRepository;
     private final CacheEvictionHelper cacheEvictionHelper;
+    private final ProductIndexingService productIndexingService;
 
     @EventListener
     @Transactional
@@ -40,11 +47,27 @@ public class ProductEventHandler {
 
         updateProductDetails(product, event.images(), event.variants());
 
-        productRepository.save(product);
+        Product savedProduct = productRepository.save(product);
 
         cacheEvictionHelper.evictAllProductListCache();
 
+        applicationEventPublisher.publishEvent(new ProductIndexedEvent(savedProduct.getId()));
         log.info("상품 생성 완료 및 캐시 갱신. categoryId: {}", event.categoryId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void indexProductAfterCreation(ProductIndexedEvent event) {
+        try {
+            Product product = productRepository.findById(event.productId())
+                .orElse(null);
+            if (product != null) {
+                productIndexingService.indexProduct(product.getId());
+                log.info("상품 인덱싱 완료. productId: {}", product.getId());
+            }
+        } catch (Exception e) {
+            log.error("상품 인덱싱 실패. productId: {}, error: {}", event.productId(), e.getMessage());
+        }
     }
 
     @EventListener
@@ -53,10 +76,10 @@ public class ProductEventHandler {
         log.info("상품 수정 이벤트 처리 시작. productId: {}", event.productId());
 
         Product product = productRepository.findById(event.productId())
-            .orElseThrow(() -> new IllegalArgumentException("Product not found"));
+            .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않습니다."));
 
         ProductCategory category = productCategoryRepository.findById(event.categoryId())
-            .orElseThrow(() -> new IllegalArgumentException("Category not found"));
+            .orElseThrow(() -> new IllegalArgumentException("카테고리가 존재하지 않습니다."));
 
         product.update(event.name(), event.description(), event.price(), category);
 
@@ -65,6 +88,7 @@ public class ProductEventHandler {
         cacheEvictionHelper.evictProductDetailCache(event.productId());
         cacheEvictionHelper.evictAllProductListCache();
 
+        applicationEventPublisher.publishEvent(new ProductIndexedEvent(event.productId()));
         log.info("상품 수정 완료 및 캐시 갱신. productId: {}", event.productId());
     }
 
@@ -81,7 +105,19 @@ public class ProductEventHandler {
         cacheEvictionHelper.evictProductDetailCache(event.productId());
         cacheEvictionHelper.evictAllProductListCache();
 
+        applicationEventPublisher.publishEvent(new ProductEvictEvent(event.productId()));
         log.info("상품 삭제 완료 및 캐시 갱신. productId: {}", event.productId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void deleteProductIndexAfterDeletion(ProductEvictEvent event) {
+        try {
+            productIndexingService.deleteProductIndex(event.productId());
+            log.info("상품 삭제 후 인덱스 삭제 완료. productId: {}", event.productId());
+        } catch (Exception e) {
+            log.error("상품 삭제 후 인덱스 삭제 실패. productId: {}, error: {}", event.productId(), e.getMessage());
+        }
     }
 
     private void updateProductDetails(Product product, List<ProductImageInfo> images, List<ProductVariantInfo> variants) {

--- a/src/main/java/xyz/product/orca_studio/module/product/application/search/IndexHealthService.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/application/search/IndexHealthService.java
@@ -1,0 +1,12 @@
+package xyz.product.orca_studio.module.product.application.search;
+
+import xyz.product.orca_studio.module.product.domain.ProductDocument;
+
+import java.util.Optional;
+
+public interface IndexHealthService {
+    boolean isIndexHealthy();
+    long getIndexedDocumentCount();
+    Optional<ProductDocument> findById(Long productId);
+    boolean isProductIndexed(Long productId);
+}

--- a/src/main/java/xyz/product/orca_studio/module/product/application/search/IndexHealthServiceImpl.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/application/search/IndexHealthServiceImpl.java
@@ -1,0 +1,60 @@
+package xyz.product.orca_studio.module.product.application.search;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import xyz.product.orca_studio.module.product.domain.ProductDocument;
+import xyz.product.orca_studio.module.product.domain.repository.ProductSearchRepository;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class IndexHealthServiceImpl implements IndexHealthService {
+
+    private final ProductSearchRepository productSearchRepository;
+
+    @Override
+    public boolean isIndexHealthy() {
+        try {
+            long count = productSearchRepository.count();
+            log.debug("ElasticSearch 인덱스 상태 확인. 총 문서 수: {}", count);
+            return true;
+        } catch (Exception e) {
+            log.error("ElasticSearch 인덱스 상태 확인 실패. error: {}", e.getMessage(), e);
+            return false;
+        }
+    }
+
+    @Override
+    public long getIndexedDocumentCount() {
+        try {
+            return productSearchRepository.count();
+        } catch (Exception e) {
+            log.error("인덱스 문서 수 조회 실패. error: {}", e.getMessage(), e);
+            return 0;
+        }
+    }
+
+    @Override
+    public Optional<ProductDocument> findById(Long productId) {
+        try {
+            return productSearchRepository.findById(productId);
+        } catch (Exception e) {
+            log.error("상품 인덱스 조회 실패. productId: {}, error: {}", productId, e.getMessage(), e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public boolean isProductIndexed(Long productId) {
+        try {
+            return productSearchRepository.existsById(productId);
+        } catch (Exception e) {
+            log.error("상품 인덱스 존재 여부 확인 실패. productId: {}, error: {}", productId, e.getMessage(), e);
+            return false;
+        }
+    }
+}
+

--- a/src/main/java/xyz/product/orca_studio/module/product/application/search/ProductBulkIndexingService.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/application/search/ProductBulkIndexingService.java
@@ -1,0 +1,8 @@
+package xyz.product.orca_studio.module.product.application.search;
+
+public interface ProductBulkIndexingService {
+    void reindexAll();
+    void reindexAllAsync();
+    void reindexByCategory(Long categoryId);
+}
+

--- a/src/main/java/xyz/product/orca_studio/module/product/application/search/ProductBulkIndexingServiceImpl.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/application/search/ProductBulkIndexingServiceImpl.java
@@ -1,0 +1,103 @@
+package xyz.product.orca_studio.module.product.application.search;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.product.orca_studio.module.product.domain.Product;
+import xyz.product.orca_studio.module.product.domain.repository.ProductRepository;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductBulkIndexingServiceImpl implements ProductBulkIndexingService {
+
+    private final ProductRepository productRepository;
+    private final ProductIndexingService productIndexingService;
+
+    private static final int BATCH_SIZE = 100;
+
+    @Override
+    @Transactional(readOnly = true)
+    public void reindexAll() {
+        log.info("전체 상품 재인덱싱 시작");
+
+        try {
+            long totalCount = productRepository.count();
+            int totalPages = (int) Math.ceil((double) totalCount / BATCH_SIZE);
+
+            log.info("전체 상품 수: {}, 배치 수: {}", totalCount, totalPages);
+
+            for (int i = 0; i < totalPages; i++) {
+                Pageable pageable = PageRequest.of(i, BATCH_SIZE);
+                Page<Product> productPage = productRepository.findAll(pageable);
+
+                List<Product> products = productPage.getContent();
+                if (!products.isEmpty()) {
+                    productIndexingService.indexProducts(products);
+                    log.info("배치 {} / {} 완료 ({} 건)", i + 1, totalPages, products.size());
+                }
+            }
+
+            log.info("전체 상품 재인덱싱 완료. 총 {}건", totalCount);
+        } catch (Exception e) {
+            log.error("전체 상품 재인덱싱 실패. error: {}", e.getMessage(), e);
+            throw new ProductIndexingException("전체 상품 재인덱싱에 실패했습니다.", e);
+        }
+    }
+
+    @Override
+    @Async
+    @Transactional(readOnly = true)
+    public void reindexAllAsync() {
+        log.info("비동기 전체 상품 재인덱싱 시작");
+
+        try {
+            reindexAll();
+        } catch (Exception e) {
+            log.error("비동기 재인덱싱 실패", e);
+            throw new ProductIndexingException("비동기 재인덱싱에 실패했습니다.", e);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public void reindexByCategory(Long categoryId) {
+        log.info("카테고리별 상품 재인덱싱 시작. categoryId: {}", categoryId);
+
+        try {
+            int page = 0;
+            Page<Product> productPage;
+            int totalProcessed = 0;
+
+            do {
+                Pageable pageable = PageRequest.of(page, BATCH_SIZE);
+                productPage = productRepository.findAll(pageable);
+
+                List<Product> products = productPage.getContent().stream()
+                    .filter(p -> p.getCategory().getId().equals(categoryId))
+                    .toList();
+
+                if (!products.isEmpty()) {
+                    productIndexingService.indexProducts(products);
+                    totalProcessed += products.size();
+                    log.info("카테고리 {} 배치 {} 완료 ({} 건)", categoryId, page + 1, products.size());
+                }
+
+                page++;
+            } while (productPage.hasNext());
+
+            log.info("카테고리별 상품 재인덱싱 완료. categoryId: {}, 총 {}건", categoryId, totalProcessed);
+        } catch (Exception e) {
+            log.error("카테고리별 재인덱싱 실패. categoryId: {}, error: {}", categoryId, e.getMessage(), e);
+            throw new ProductIndexingException("카테고리별 재인덱싱에 실패했습니다.", e);
+        }
+    }
+}
+

--- a/src/main/java/xyz/product/orca_studio/module/product/application/search/ProductIndexingException.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/application/search/ProductIndexingException.java
@@ -1,0 +1,13 @@
+package xyz.product.orca_studio.module.product.application.search;
+
+public class ProductIndexingException extends RuntimeException {
+
+    public ProductIndexingException(String message) {
+        super(message);
+    }
+
+    public ProductIndexingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/src/main/java/xyz/product/orca_studio/module/product/application/search/ProductIndexingService.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/application/search/ProductIndexingService.java
@@ -1,0 +1,13 @@
+package xyz.product.orca_studio.module.product.application.search;
+
+import xyz.product.orca_studio.module.product.domain.Product;
+
+import java.util.List;
+
+public interface ProductIndexingService {
+    void indexProduct(Long productId);
+    void indexProducts(List<Product> products);
+    void deleteProductIndex(Long productId);
+    void deleteAllIndices();
+}
+

--- a/src/main/java/xyz/product/orca_studio/module/product/application/search/ProductIndexingServiceImpl.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/application/search/ProductIndexingServiceImpl.java
@@ -1,0 +1,85 @@
+package xyz.product.orca_studio.module.product.application.search;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import xyz.product.orca_studio.module.product.domain.Product;
+import xyz.product.orca_studio.module.product.domain.ProductDocument;
+import xyz.product.orca_studio.module.product.domain.repository.ProductRepository;
+import xyz.product.orca_studio.module.product.domain.repository.ProductSearchRepository;
+import xyz.product.orca_studio.module.product.mapper.ProductDocumentMapper;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductIndexingServiceImpl implements ProductIndexingService {
+
+    private final ProductSearchRepository productSearchRepository;
+    private final ProductDocumentMapper productDocumentMapper;
+    private final ProductRepository productRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public void indexProduct(Long productId) {
+        try {
+            Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new EntityNotFoundException("인덱싱하려는 상품이 존재하지 않습니다."));
+
+            ProductDocument document = productDocumentMapper.toDocument(product);
+            productSearchRepository.save(document);
+            log.info("상품 인덱싱 완료. productId: {}", productId);
+        } catch (Exception e) {
+            log.error("상품 인덱싱 실패. productId: {}, error: {}", productId, e.getMessage(), e);
+            throw new ProductIndexingException("상품 인덱싱에 실패했습니다.", e);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public void indexProducts(List<Product> products) {
+        if (products == null || products.isEmpty()) {
+            log.warn("인덱싱할 상품 목록이 비어있습니다.");
+            return;
+        }
+
+        try {
+            List<ProductDocument> documents = products.stream()
+                .map(productDocumentMapper::toDocument)
+                .toList();
+            productSearchRepository.saveAll(documents);
+            log.info("상품 대량 인덱싱 완료. count: {}", products.size());
+        } catch (Exception e) {
+            log.error("상품 대량 인덱싱 실패. count: {}, error: {}", products.size(), e.getMessage(), e);
+            throw new ProductIndexingException("상품 대량 인덱싱에 실패했습니다.", e);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public void deleteProductIndex(Long productId) {
+        try {
+            productSearchRepository.deleteById(productId);
+            log.info("상품 인덱스 삭제 완료. productId: {}", productId);
+        } catch (Exception e) {
+            log.error("상품 인덱스 삭제 실패. productId: {}, error: {}", productId, e.getMessage(), e);
+            throw new ProductIndexingException("상품 인덱스 삭제에 실패했습니다.", e);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public void deleteAllIndices() {
+        try {
+            productSearchRepository.deleteAll();
+            log.info("모든 상품 인덱스 삭제 완료");
+        } catch (Exception e) {
+            log.error("모든 상품 인덱스 삭제 실패. error: {}", e.getMessage(), e);
+            throw new ProductIndexingException("모든 상품 인덱스 삭제에 실패했습니다.", e);
+        }
+    }
+}
+

--- a/src/main/java/xyz/product/orca_studio/module/product/domain/ProductDocument.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/domain/ProductDocument.java
@@ -1,0 +1,109 @@
+package xyz.product.orca_studio.module.product.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.*;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(indexName = "products", createIndex = true)
+@Setting(settingPath = "/elasticsearch/product-settings.json")
+public class ProductDocument {
+
+    @Id
+    private Long id;
+
+    @Field(type = FieldType.Text, analyzer = "nori_analyzer")
+    private String name;
+
+    @Field(type = FieldType.Text, analyzer = "nori_analyzer")
+    private String description;
+
+    @Field(type = FieldType.Double)
+    private Double price;
+
+    @Field(type = FieldType.Double)
+    private Double minPrice;
+
+    @Field(type = FieldType.Double)
+    private Double maxPrice;
+
+    @Field(type = FieldType.Long)
+    private Long categoryId;
+
+    @Field(type = FieldType.Keyword)
+    private String categoryName;
+
+    @Field(type = FieldType.Keyword)
+    private String status;
+
+    @Field(type = FieldType.Keyword)
+    private String thumbnailUrl;
+
+    @Field(type = FieldType.Nested)
+    private Set<ProductVariantDocument> variants;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis)
+    private LocalDateTime createdAt;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public ProductDocument(Long id, String name, String description, Double price,
+                           Double minPrice, Double maxPrice, Long categoryId,
+                           String categoryName, String status, String thumbnailUrl,
+                           Set<ProductVariantDocument> variants, LocalDateTime createdAt,
+                           LocalDateTime updatedAt) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.price = price;
+        this.minPrice = minPrice;
+        this.maxPrice = maxPrice;
+        this.categoryId = categoryId;
+        this.categoryName = categoryName;
+        this.status = status;
+        this.thumbnailUrl = thumbnailUrl;
+        this.variants = variants;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ProductVariantDocument {
+
+        @Field(type = FieldType.Long)
+        private Long id;
+
+        @Field(type = FieldType.Keyword)
+        private String color;
+
+        @Field(type = FieldType.Keyword)
+        private String size;
+
+        @Field(type = FieldType.Integer)
+        private Integer stock;
+
+        @Field(type = FieldType.Double)
+        private Double additionalPrice;
+
+        @Builder
+        public ProductVariantDocument(Long id, String color, String size, Integer stock,
+                                      Double additionalPrice) {
+            this.id = id;
+            this.color = color;
+            this.size = size;
+            this.stock = stock;
+            this.additionalPrice = additionalPrice;
+        }
+    }
+}
+

--- a/src/main/java/xyz/product/orca_studio/module/product/domain/repository/ProductSearchRepository.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/domain/repository/ProductSearchRepository.java
@@ -1,0 +1,16 @@
+package xyz.product.orca_studio.module.product.domain.repository;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+import xyz.product.orca_studio.module.product.domain.ProductDocument;
+
+import java.util.List;
+
+@Repository
+public interface ProductSearchRepository extends ElasticsearchRepository<ProductDocument, Long> {
+
+    List<ProductDocument> findByCategoryId(Long categoryId);
+
+    List<ProductDocument> findByStatus(String status);
+}
+

--- a/src/main/java/xyz/product/orca_studio/module/product/mapper/ProductDocumentMapper.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/mapper/ProductDocumentMapper.java
@@ -1,0 +1,51 @@
+package xyz.product.orca_studio.module.product.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import xyz.product.orca_studio.module.product.domain.*;
+
+import java.math.BigDecimal;
+
+@Mapper(componentModel = "spring")
+public interface ProductDocumentMapper {
+
+    @Mapping(target = "categoryId", source = "category.id")
+    @Mapping(target = "categoryName", source = "category.name")
+    @Mapping(target = "status", expression = "java(product.getStatus().name())")
+    @Mapping(target = "thumbnailUrl", expression = "java(extractThumbnailUrl(product))")
+    @Mapping(target = "variants", source = "variants")
+    @Mapping(target = "price", expression = "java(product.getPrice() != null ? product.getPrice().doubleValue() : null)")
+    @Mapping(target = "minPrice", expression = "java(calculateMinPrice(product) != null ? calculateMinPrice(product).doubleValue() : null)")
+    @Mapping(target = "maxPrice", expression = "java(calculateMaxPrice(product) != null ? calculateMaxPrice(product).doubleValue() : null)")
+    ProductDocument toDocument(Product product);
+
+    @Mapping(target = "id", source = "id")
+    ProductDocument.ProductVariantDocument toVariantDocument(ProductVariant variant);
+
+    default String extractThumbnailUrl(Product product) {
+        return product.getImages().stream()
+            .filter(img -> img.getDivision() == ImageDivision.THUMBNAIL)
+            .findFirst()
+            .map(ProductImage::getImageUrl)
+            .orElse(null);
+    }
+
+    default BigDecimal calculateMinPrice(Product product) {
+        BigDecimal basePrice = product.getPrice();
+        BigDecimal minAdditional = product.getVariants().stream()
+            .map(ProductVariant::getAdditionalPrice)
+            .min(BigDecimal::compareTo)
+            .orElse(BigDecimal.ZERO);
+        return basePrice.add(minAdditional);
+    }
+
+    default BigDecimal calculateMaxPrice(Product product) {
+        BigDecimal basePrice = product.getPrice();
+        BigDecimal maxAdditional = product.getVariants().stream()
+            .map(ProductVariant::getAdditionalPrice)
+            .max(BigDecimal::compareTo)
+            .orElse(BigDecimal.ZERO);
+        return basePrice.add(maxAdditional);
+    }
+}
+

--- a/src/main/java/xyz/product/orca_studio/module/product/simulation/ProductSimulationController.java
+++ b/src/main/java/xyz/product/orca_studio/module/product/simulation/ProductSimulationController.java
@@ -15,7 +15,6 @@ import xyz.product.orca_studio.module.product.simulation.dto.UpdateProductReques
 @RestController
 @RequestMapping("/api/simulate/products")
 @RequiredArgsConstructor
-// This controller should ideally be active only on 'dev' or 'simulation' profiles.
 public class ProductSimulationController {
 
     private final ApplicationEventPublisher eventPublisher;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,3 +23,7 @@ spring:
     redis:
       host: ${CACHE_HOST}
       port: ${CACHE_PORT}
+
+  elasticsearch:
+    uris: ${ELASTICSEARCH_URI}
+

--- a/src/main/resources/elasticsearch/product-settings.json
+++ b/src/main/resources/elasticsearch/product-settings.json
@@ -1,0 +1,17 @@
+{
+    "analysis": {
+        "tokenizer": {
+            "nori_tokenizer_mixed": {
+                "type": "nori_tokenizer",
+                "decompound_mode": "mixed"
+            }
+        },
+        "analyzer": {
+            "nori_analyzer": {
+                "type": "custom",
+                "tokenizer": "nori_tokenizer_mixed",
+                "filter": ["lowercase"]
+            }
+        }
+    }
+}

--- a/src/test/java/xyz/product/orca_studio/OrcaStudioApplicationTests.java
+++ b/src/test/java/xyz/product/orca_studio/OrcaStudioApplicationTests.java
@@ -3,17 +3,10 @@ package xyz.product.orca_studio;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 class OrcaStudioApplicationTests {
-
-    @DynamicPropertySource
-    static void overrideProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.data.redis.port", () -> 6379);
-    }
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/xyz/product/orca_studio/TestcontainersConfiguration.java
+++ b/src/test/java/xyz/product/orca_studio/TestcontainersConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
@@ -21,5 +22,14 @@ class TestcontainersConfiguration {
     RedisContainer redisContainer() {
         return new RedisContainer(DockerImageName.parse("redis:7-alpine"))
             .withExposedPorts(6379);
+    }
+
+    @Bean
+    @ServiceConnection
+    @SuppressWarnings("resource")
+    ElasticsearchContainer elasticsearchContainer() {
+        return new ElasticsearchContainer(DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:8.11.0"))
+            .withEnv("xpack.security.enabled", "false")
+            .withEnv("discovery.type", "single-node");
     }
 }

--- a/src/test/java/xyz/product/orca_studio/TestcontainersConfiguration.java
+++ b/src/test/java/xyz/product/orca_studio/TestcontainersConfiguration.java
@@ -1,15 +1,26 @@
 package xyz.product.orca_studio;
 
-import com.redis.testcontainers.RedisContainer;
+import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.time.Duration;
+
 @TestConfiguration(proxyBeanMethods = false)
 class TestcontainersConfiguration {
+    static {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        dotenv.entries().forEach(entry ->
+            System.setProperty(entry.getKey(), entry.getValue())
+        );
+    }
+
     @Bean
     @ServiceConnection
     MySQLContainer<?> mysqlContainer() {
@@ -17,19 +28,25 @@ class TestcontainersConfiguration {
     }
 
     @Bean
-    @ServiceConnection
-    @SuppressWarnings("resource")
-    RedisContainer redisContainer() {
-        return new RedisContainer(DockerImageName.parse("redis:7-alpine"))
+    @ServiceConnection(name = "redis")
+    GenericContainer<?> redisContainer() {
+        return new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
             .withExposedPorts(6379);
     }
 
     @Bean
     @ServiceConnection
-    @SuppressWarnings("resource")
     ElasticsearchContainer elasticsearchContainer() {
-        return new ElasticsearchContainer(DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:8.11.0"))
+        return new ElasticsearchContainer(DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:9.2.4"))
             .withEnv("xpack.security.enabled", "false")
-            .withEnv("discovery.type", "single-node");
+            .withEnv("xpack.security.http.ssl.enabled", "false")
+            .withEnv("discovery.type", "single-node")
+            .withEnv("ES_JAVA_OPTS", "-Xms1g -Xmx1g")
+            .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint(
+                "sh", "-c",
+                "bin/elasticsearch-plugin install analysis-nori && /usr/local/bin/docker-entrypoint.sh"
+            ))
+            .waitingFor(Wait.forListeningPort())
+            .withStartupTimeout(Duration.ofMinutes(3));
     }
 }


### PR DESCRIPTION
## 📝 설명
<!-- 어떤 작업을 했는지 간략히 설명해주세요 -->

- `Elasticsearch` 인덱싱 파이프라인 구축

---

## ✅ 체크리스트
<!-- 코드가 정상적으로 작동하는지 확인함 -->

- [ ] `CI`가 정상적으로 처리되는가?
- [x] 상품 생성 이벤트 발행 시 인덱스가 생성이 되는가?
- [x] 상품 수정 이벤트 발행 시 인덱스가 수정이 되는가?
- [x] 상품 삭제 이벤트 발행시 인덱스가 삭제가 되는가?
- [x] 관리자 전용 재인덱싱 `API`가 정상적으로 동작하는가?

---

## 📂 관련 이슈
<!-- 이 PR이 관련된 이슈 번호를 연결해주세요 (예: Closes #42) -->

Closes #9 

---

## 📌 기타 참고사항
<!-- 코드 리뷰어가 참고하면 좋을 만한 내용을 추가해주세요 -->

- 비동기 처리에 `Entity` 객체를 직접 넘길 경우 발생한 이슈사항

1. 문제
비동기 스레드(`@Async`)에서 엔티티의 연관 관계에 접근할 때 `LazyInitializationException`(`no session`) 에러가 발생하며 프로세스가 중단

2. 원인
세션의 격리: `JPA`의 영속성 컨텍스트는 스레드 단위로 관리됨
준영속 상태: 메인 스레드의 트랜잭션이 끝나면 엔티티는 세션이 끊긴 준영속(`Detached`) 상태가 됨
프록시 초기화 불가: 비동기 스레드는 메인 스레드의 세션을 공유하지 않으므로, 준영속 상태인 엔티티의 지연 로딩(`Lazy Loading`) 데이터를 `DB`에서 추가로 읽어올 방법이 없음

3. 해결
엔티티 대신 `ID`(식별자)를 넘기고, 비동기 메서드 내부에서 다시 조회
비동기 스레드에서 `@Transactional(readOnly = true)`를 통해 새로운 세션을 열 경우,
`findById()`로 엔티티를 새로 조회하여 모든 연관 데이터를 안전하게 로딩할 수 있음